### PR TITLE
Add option for toggling thirdperson

### DIFF
--- a/GMod-SDK/GMod-SDK.vcxproj
+++ b/GMod-SDK/GMod-SDK.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/GMod-SDK/globals.hpp
+++ b/GMod-SDK/globals.hpp
@@ -297,6 +297,7 @@ namespace Settings {
 		bool thirdperson;
 		ButtonCode_t thirdpersonKey = KEY_NONE;
 		int thirdpersonKeyStyle = 1;
+		bool toggleThirdperson;
 		float thirdpersonDistance;
 
 		bool removeHands;

--- a/GMod-SDK/hacks/ConfigSystem.h
+++ b/GMod-SDK/hacks/ConfigSystem.h
@@ -139,6 +139,7 @@ namespace ConfigSystem
 		j["Misc"]["thirdperson"] = Settings::Misc::thirdperson;
 		j["Misc"]["thirdpersonKey"] = Settings::Misc::thirdpersonKey;
 		j["Misc"]["thirdpersonKeyStyle"] = Settings::Misc::thirdpersonKeyStyle;
+		j["Misc"]["toggleThirdperson"] = Settings::Misc::toggleThirdperson;
 		j["Misc"]["thirdpersonDistance"] = Settings::Misc::thirdpersonDistance;
 		j["Misc"]["removeHands"] = Settings::Misc::removeHands;
 		j["Misc"]["flashlightSpam"] = Settings::Misc::flashlightSpam;
@@ -415,6 +416,7 @@ namespace ConfigSystem
 		Settings::Misc::thirdperson = NULL;
 		Settings::Misc::thirdpersonKey = KEY_NONE;
 		Settings::Misc::thirdpersonKeyStyle = 1;
+		Settings::Misc::toggleThirdperson = NULL;
 		Settings::Misc::thirdpersonDistance = 20.f;
 		Settings::Misc::removeHands = NULL;
 		Settings::Misc::flashlightSpam = NULL;

--- a/GMod-SDK/hacks/menu/GUI.h
+++ b/GMod-SDK/hacks/menu/GUI.h
@@ -215,6 +215,7 @@ namespace GUI
 
 				Menu::InsertCheckbox("Third person", &Settings::Misc::thirdperson);
 				ImGui::Keybind("thirdpersonkey", (int*)&Settings::Misc::thirdpersonKey, &Settings::Misc::thirdpersonKeyStyle);
+				Menu::InsertCheckbox("Toggle third person", &Settings::Misc::toggleThirdperson);
 				Menu::InsertSlider("Third person distance", &Settings::Misc::thirdpersonDistance, 20, 1000);
 
 				Menu::InsertCheckbox("Full Bright", &Settings::Visuals::fullBright);

--- a/GMod-SDK/hooks/FrameStageNotify.h
+++ b/GMod-SDK/hooks/FrameStageNotify.h
@@ -108,7 +108,9 @@ ClientFrameStage_t stage)
 	bool freecamKeyDown = false;
 	getKeyState(Settings::Misc::freeCamKey, Settings::Misc::freeCamKeyStyle, &freecamKeyDown);
 
-	bool needsSetViewAngles = (Settings::Misc::thirdperson && thirdpKeyDown) || (Settings::Misc::freeCam && freecamKeyDown);
+	// check toggle instead of key if we have the toggle option on
+	bool thirdPersonEnabled = (Settings::Misc::thirdperson && (Settings::Misc::toggleThirdperson || thirdpKeyDown));
+	bool needsSetViewAngles = thirdPersonEnabled || (Settings::Misc::freeCam && freecamKeyDown);
 
 	if(localPlayer && localPlayer->IsAlive() && stage == ClientFrameStage_t::FRAME_RENDER_START && needsSetViewAngles)
 		localPlayer->SetLocalViewAngles(Globals::lastNetworkedCmd.viewangles);

--- a/GMod-SDK/hooks/RenderView.h
+++ b/GMod-SDK/hooks/RenderView.h
@@ -30,19 +30,30 @@ CViewSetup& view, int nClearFlags, int whatToDraw)
 
 	bool thirdpKeyDown = false;
 	getKeyState(Settings::Misc::thirdpersonKey, Settings::Misc::thirdpersonKeyStyle, &thirdpKeyDown, henlo1, henlo2, henlo3);
+	
+	static bool shouldDetectPress = true;	// This variable will be true on the first time the button is pressed
+	if (thirdpKeyDown) {
+		if (shouldDetectPress) {
+			// Toggle thirdperson setting itself
+			if (Settings::Misc::toggleThirdperson) Settings::Misc::thirdperson = !Settings::Misc::thirdperson;
+			shouldDetectPress = false;		// And ignore after toggle until button is released
+		}
+	}
+	else shouldDetectPress = true;
+
+	bool thirdPersonEnabled = (Settings::Misc::thirdperson && (Settings::Misc::toggleThirdperson || thirdpKeyDown));
+
 	static bool lastThirdPersonState = false;
-	if (localPlayer && Settings::Misc::thirdperson && thirdpKeyDown) {
+	if (localPlayer && thirdPersonEnabled) {
 		lastThirdPersonState = true;
 		ThirdPerson(view);
 		view.angles = Globals::lastCmd.viewangles;
 
-		Input->m_fCameraInThirdPerson = true;		
+		Input->m_fCameraInThirdPerson = true;
 	}
-	else {
-		if (lastThirdPersonState)
-			Input->m_fCameraInThirdPerson = false;
+	else if (lastThirdPersonState) {
+		Input->m_fCameraInThirdPerson = false;
 		lastThirdPersonState = false;
-		
 	}
 
 	bool freeCamKeyDown = false;


### PR DESCRIPTION
Adds a new checkbox option in the menu for toggling the thirdperson.

If this option is enabled, the thirdperson key won't act as a "hold" key anymore, it will act as a switch for the thirdperson.